### PR TITLE
Better serial I/O

### DIFF
--- a/fujicom/GNUmakefile
+++ b/fujicom/GNUmakefile
@@ -1,5 +1,6 @@
 all:
-	wmake -e CPPFLAGS=-DSERIAL_BPS=115200
+#	wmake -e CPPFLAGS=-DSERIAL_BPS=115200
+	wmake -e
 
 clean:
 	wmake clean

--- a/fujicom/com.c
+++ b/fujicom/com.c
@@ -412,6 +412,8 @@ uint16_t port_getbuf(PORT far *port, uint8_t far *buf, uint16_t len, uint16_t ti
   uint16_t rlen;
 
 
+  _disable();
+  
   for (rlen = 0; rlen < len; rlen++, buf++) {
     timeout_start();
     for (;;) {
@@ -420,12 +422,14 @@ uint16_t port_getbuf(PORT far *port, uint8_t far *buf, uint16_t len, uint16_t ti
         break;
       timeout_now();
       if (timeout && timeout_delta() > timeout)
-        return rlen;
+	goto done;
     }
 
     *buf = inportb(port->uart_base + RBR);
   }
 
+ done:
+  _enable();
   return rlen;
 }
 

--- a/fujicom/fujicom.c
+++ b/fujicom/fujicom.c
@@ -146,6 +146,7 @@ char fujicom_command_read(cmdFrame_t far *cmd, uint8_t far *buf, uint16_t len)
     if (ck1 != ck2) {
       consolef("FN checksum error\n");
       reply = 'E';
+      continue;
     }
 
     /* No errors, we're done! */

--- a/sys/init.c
+++ b/sys/init.c
@@ -59,8 +59,7 @@ uint16_t Init_cmd(SYSREQ far *req)
   fujicom_init();
   check_uart();
 
-  // FIXME - check if /NOTIME was passed on command line
-  err = get_set_time(1);
+  err = get_set_time(!getenv("NOTIME"));
 
   // If get_set_time returned error, FujiNet is probably not connected
   if (err) {
@@ -111,6 +110,7 @@ uint8_t get_set_time(uint8_t set_flag)
   uint16_t year_wcen;
 
 
+  consolef("GET SET TIME: %i\n", set_flag);
   cmd.device = DEVICEID_APETIME;
   cmd.comnd = APETIMECMD_GETTZTIME;
 


### PR DESCRIPTION
* Retry packet read and packet write on all errors
* Disable interrupts in `port_getbuf()` to try to prevent dropping characters at higher speeds
* Added NOTIME option to prevent setting MS-DOS clock after fetching time from FujiNet