### PR TITLE
Define more constants for FujiNet commands.

### DIFF
--- a/fujicom/fujicom.c
+++ b/fujicom/fujicom.c
@@ -68,7 +68,7 @@ uint8_t fujicom_cksum(uint8_t far *buf, uint16_t len)
  * @param c ptr to command frame to send
  * @return 'A'ck, or 'N'ak.
  */
-char _fujicom_send_command(cmdFrame_t far *cmd)
+int _fujicom_send_command(cmdFrame_t far *cmd)
 {
   uint8_t *cc = (uint8_t *) cmd;
 
@@ -88,7 +88,7 @@ char _fujicom_send_command(cmdFrame_t far *cmd)
   return port_getc_nobuf(port, TIMEOUT);
 }
 
-char fujicom_command(cmdFrame_t far *cmd)
+int fujicom_command(cmdFrame_t far *cmd)
 {
   int reply;
 
@@ -103,7 +103,7 @@ char fujicom_command(cmdFrame_t far *cmd)
   return reply;
 }
 
-char fujicom_command_read(cmdFrame_t far *cmd, uint8_t far *buf, uint16_t len)
+int fujicom_command_read(cmdFrame_t far *cmd, uint8_t far *buf, uint16_t len)
 {
   int reply;
   uint16_t rlen;
@@ -163,7 +163,7 @@ char fujicom_command_read(cmdFrame_t far *cmd, uint8_t far *buf, uint16_t len)
   return reply;
 }
 
-char fujicom_command_write(cmdFrame_t far *cmd, uint8_t far *buf, uint16_t len)
+int fujicom_command_write(cmdFrame_t far *cmd, uint8_t far *buf, uint16_t len)
 {
   int reply;
   uint8_t ck;

--- a/fujicom/fujicom.h
+++ b/fujicom/fujicom.h
@@ -7,6 +7,13 @@
 
 #include <stdint.h>
 
+#define FUJINET_INT     0xF5
+#define FUJIINT_NONE    0x00
+#define FUJIINT_READ    0x40
+#define FUJIINT_WRITE   0x80
+
+#define FUJICOM_TIMOUT  -1
+
 // FIXME - get these constants and structs from
 //         fujinet-firmware/lib/bus/rs232/rs232.h instead of
 //         redefining them here
@@ -36,9 +43,16 @@ enum {
 };
 
 enum {
-  APETIMECMD_GETTIME    = 0x93,
-  APETIMECMD_SETTZ      = 0x99,
-  APETIMECMD_GETTZTIME  = 0x9A,
+  CMD_OPEN                      = 'O',
+  CMD_CLOSE                     = 'C',
+  CMD_READ                      = 'R',
+  CMD_WRITE                     = 'W',
+  CMD_STATUS                    = 'S',
+  CMD_APETIME_GETTIME           = 0x93,
+  CMD_APETIME_SETTZ             = 0x99,
+  CMD_APETIME_GETTZTIME         = 0x9A,
+  CMD_USERNAME                  = 0xFD,
+  CMD_PASSWORD                  = 0xFE,
 };
 
 /**
@@ -58,7 +72,7 @@ uint8_t fujicom_cksum(uint8_t far *buf, uint16_t len);
  * @param cmdFrame Pointer to command frame
  * @return 'C'omplete, 'E'rror, or 'N'ak
  */
-char fujicom_command(cmdFrame_t far *c);
+int fujicom_command(cmdFrame_t far *c);
 
 /**
  * @brief send fujinet frame and read payload
@@ -66,7 +80,7 @@ char fujicom_command(cmdFrame_t far *c);
  * @param buf Pointer to buffer to receive
  * @param len Expected buffer length
  */
-char fujicom_command_read(cmdFrame_t far *c, uint8_t far *buf, uint16_t len);
+int fujicom_command_read(cmdFrame_t far *c, uint8_t far *buf, uint16_t len);
 
 /**
  * @brief send fujinet frame and write payload
@@ -74,7 +88,7 @@ char fujicom_command_read(cmdFrame_t far *c, uint8_t far *buf, uint16_t len);
  * @param buf pointer to buffer to send.
  * @param len Length of buffer to send.
  */
-char fujicom_command_write(cmdFrame_t far *c, uint8_t far *buf, uint16_t len);
+int fujicom_command_write(cmdFrame_t far *c, uint8_t far *buf, uint16_t len);
 
 /**
  * @brief end fujicom

--- a/sys/commands.c
+++ b/sys/commands.c
@@ -38,7 +38,7 @@ uint16_t Build_bpb_cmd(SYSREQ far *req)
   }
 
   cmd.device = DEVICEID_DISK + req->unit;
-  cmd.comnd = 'R'; /* Read */
+  cmd.comnd = CMD_READ;
   cmd.aux1 = cmd.aux2 = 0;
 
   // DOS gave us a buffer to use?
@@ -89,10 +89,15 @@ uint16_t Input_cmd(SYSREQ far *req)
   dumpHex((uint8_t far *) req, req->length);
   consolef("SECTOR: 0x%x\n", sector);
 #endif
-  
+
   for (idx = 0; idx < req->req_type.i_o_req.count; idx++, sector++) {
+    if (sector >= fn_bpb_table[req->unit].num_sectors) {
+      consolef("FN Invalid sector read %i on %c:\n", sector, 'A' + req->unit);
+      return ERROR_BIT | NOT_FOUND;
+    }
+
     cmd.device = DEVICEID_DISK + req->unit;
-    cmd.comnd = 'R'; /* Read */
+    cmd.comnd = CMD_READ;
     cmd.aux1 = sector & 0xFF;
     cmd.aux2 = sector >> 8;
 

--- a/sys/init.c
+++ b/sys/init.c
@@ -105,7 +105,7 @@ uint8_t get_set_time(uint8_t set_flag)
 
 
   cmd.device = DEVICEID_APETIME;
-  cmd.comnd = APETIMECMD_GETTZTIME;
+  cmd.comnd = CMD_APETIME_GETTZTIME;
 
   reply = fujicom_command_read(&cmd, (uint8_t *) &cur_time, sizeof(cur_time));
 


### PR DESCRIPTION
Defines a lot more constants and also changes the fujicom_command* functions to return an `int` instead of `char` to distinguish between FUJICOM_TIMEOUT and valid 8bit data.