### PR TITLE
Build fujinet.sys via GitHub Actions

### DIFF
--- a/.github/workflows/build-sys.yaml
+++ b/.github/workflows/build-sys.yaml
@@ -21,6 +21,9 @@ jobs:
         id: short-sha
         run: echo "sha=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
 
+      - name: Git Safe Directory
+        run: git config --global --add safe.directory ${{ github.workspace }}
+
       - name: Setup Watcom 
         uses: open-watcom/setup-watcom@v0
         with:

--- a/.github/workflows/build-sys.yaml
+++ b/.github/workflows/build-sys.yaml
@@ -42,10 +42,9 @@ jobs:
       
       - name: Bump version and push tag
         id: tag-version
-        uses: ChloePlanet/github-tag-action@master
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          WITH_V: true
+        uses: laputansoft/github-tag-action@v4.6
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Create Release
         uses: softprops/action-gh-release@v2

--- a/.github/workflows/build-sys.yaml
+++ b/.github/workflows/build-sys.yaml
@@ -13,7 +13,7 @@ jobs:
       
       - name: Get short SHA
         id: short-sha
-        run: echo "::set-output name=sha::$(git rev-parse --short HEAD)"
+        run: echo "sha=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
 
       - name: Setup Watcom 
         uses: open-watcom/setup-watcom@v0
@@ -27,7 +27,9 @@ jobs:
 
       - name: Build fujinet.sys
         working-directory: sys/
-        run: make
+        run: | 
+          make
+          cp fujinet.sys fujinet-${{ steps.short-sha.outputs.sha }}.sys
 
       - name: Create Release
         uses: softprops/action-gh-release@v2

--- a/.github/workflows/build-sys.yaml
+++ b/.github/workflows/build-sys.yaml
@@ -44,6 +44,7 @@ jobs:
         id: tag-version
         uses: ChloePlanet/github-tag-action@master
         env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           WITH_V: true
 
       - name: Create Release

--- a/.github/workflows/build-sys.yaml
+++ b/.github/workflows/build-sys.yaml
@@ -36,6 +36,12 @@ jobs:
         run: | 
           make
           cp fujinet.sys fujinet-${{ steps.short-sha.outputs.sha }}.sys
+      
+      - name: Bump version and push tag
+        id: tag-version
+        uses: ChloePlanet/github-tag-action@master
+        env:
+          WITH_V: true
 
       - name: Create Release
         uses: softprops/action-gh-release@v2
@@ -43,7 +49,7 @@ jobs:
           body: | 
             `fujinet.sys` MS-DOS driver for RS232 FujiNet
           name: fujinet.sys - {{ steps.short-sha.outputs.sha }}
-          tag_name: fujinet.sys
+          tag_name: ${{ steps.tag-version.outputs.new_tag }}
           prerelease: true 
           files: ${{ github.workspace }}/sys/fujinet-${{ steps.short-sha.outputs.sha }}.sys
           generate_release_notes: true 

--- a/.github/workflows/build-sys.yaml
+++ b/.github/workflows/build-sys.yaml
@@ -1,6 +1,12 @@
 name: Build fujinet.sys
 
 on: 
+  push: 
+    branches:
+      - main
+    paths:
+      - 'sys/**'
+      - 'fujicom/**'
   workflow_dispatch:
     
 jobs:
@@ -36,7 +42,7 @@ jobs:
         with:
           body: | 
             `fujinet.sys` MS-DOS driver for RS232 FujiNet
-          name: fujinet.sys - Nightly Build
+          name: fujinet.sys - {{ steps.short-sha.outputs.sha }}
           tag_name: fujinet.sys
           prerelease: true 
           files: ${{ github.workspace }}/sys/fujinet-${{ steps.short-sha.outputs.sha }}.sys

--- a/.github/workflows/build-sys.yaml
+++ b/.github/workflows/build-sys.yaml
@@ -51,7 +51,6 @@ jobs:
         with:
           body: | 
             `fujinet.sys` MS-DOS driver for RS232 FujiNet
-          name: fujinet.sys - {{ steps.short-sha.outputs.sha }}
           tag_name: ${{ steps.tag-version.outputs.new_tag }}
           prerelease: true 
           files: ${{ github.workspace }}/sys/fujinet-${{ steps.short-sha.outputs.sha }}.sys

--- a/.github/workflows/build-sys.yaml
+++ b/.github/workflows/build-sys.yaml
@@ -1,0 +1,40 @@
+name: Build fujinet.sys
+
+on: 
+  workflow_dispatch:
+    
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+      
+      - name: Get short SHA
+        id: short-sha
+        run: echo "::set-output name=sha::$(git rev-parse --short HEAD)"
+
+      - name: Setup Watcom 
+        uses: open-watcom/setup-watcom@v0
+        with:
+          version: "2.0"
+      
+      - name: Build fujicom
+        working-directory: fujicom/
+        run: make
+
+      - name: Build fujinet.sys
+        working-directory: sys/
+        run: make
+
+      - name: Create Release
+        uses: softprops/action-gh-release@v2
+        with:
+          body: | 
+            `fujinet.sys` MS-DOS driver for RS232 FujiNet
+          name: fujinet.sys
+          prerelease: true 
+          files: ${{ github.workspace }}/sys/fujinet-${{ steps.short-sha.outputs.sha }}.sys
+          generate_release_notes: true 
+          make_latest: true 

--- a/.github/workflows/build-sys.yaml
+++ b/.github/workflows/build-sys.yaml
@@ -19,6 +19,7 @@ jobs:
         uses: open-watcom/setup-watcom@v0
         with:
           version: "2.0"
+          target: dos
       
       - name: Build fujicom
         working-directory: fujicom/

--- a/.github/workflows/build-sys.yaml
+++ b/.github/workflows/build-sys.yaml
@@ -34,7 +34,8 @@ jobs:
         with:
           body: | 
             `fujinet.sys` MS-DOS driver for RS232 FujiNet
-          name: fujinet.sys
+          name: fujinet.sys - Nightly Build
+          tag_name: fujinet.sys
           prerelease: true 
           files: ${{ github.workspace }}/sys/fujinet-${{ steps.short-sha.outputs.sha }}.sys
           generate_release_notes: true 


### PR DESCRIPTION
Generates a tag & release with `fujinet.sys` attached as an asset automatically when there are any changes in the `fujicom/` or `sys/` directories.  Looks like this: 

![image](https://github.com/user-attachments/assets/398e0ff0-75b2-4e73-b922-98509d826562)
