### PR TITLE
[printer] fix INT17 status byte.

### DIFF
--- a/printer/int17.c
+++ b/printer/int17.c
@@ -30,11 +30,14 @@ int int17(uint16_t direction, uint16_t cmdchar, uint16_t aux12, uint16_t aux34,
     {
     case 0:
         prn_buf_add(al);
-        return 0;
+	direction = aux12 = aux34 = cmdchar = 0x9000;
+        return 0x9000;
     case 1:
-        return 0;
+	direction = aux12 = aux34 = cmdchar = 0x9000;
+	return 0x9000;
     case 2:
-        return 0;
+	direction = aux12 = aux34 = cmdchar = 0x9000;
+        return 0x9000;
     }
 
     return 0;


### PR DESCRIPTION
INT17 now returns correct status byte, so that programs like The Print Shop work.