### PR TITLE
Print flush buffer timer

### DIFF
--- a/printer/commands.c
+++ b/printer/commands.c
@@ -8,9 +8,22 @@
 extern void End_code(void);
 
 #define PRN_BUF_SIZE 255
+#define AUTO_FLUSH_TICKS (18 * 5)  // 5 seconds at 18.2 Hz
 
 static unsigned char prn_buf[PRN_BUF_SIZE];
 static uint16_t prn_buf_len = 0;
+static volatile uint16_t timer_counter = 0;
+static volatile uint16_t last_activity = 0;
+static volatile uint8_t flush_pending = 0;
+static uint8_t far *indos_flag = NULL;
+
+// Defined in iwrap.asm
+extern uint16_t old_timer_off;
+extern uint16_t old_timer_seg;
+extern void timer_vect(void);
+extern uint16_t old_idle_off;
+extern uint16_t old_idle_seg;
+extern void idle_vect(void);
 
 int flush_prn_buf(void)
 {
@@ -18,6 +31,7 @@ int flush_prn_buf(void)
     if (prn_buf_len > 0) {
         ok = fujiF5_write(FUJI_DEVICEID_PRINTER, FUJICMD_WRITE, FUJI_FIELD_NONE, 0, 0, prn_buf, prn_buf_len);
         prn_buf_len = 0;
+        memset(prn_buf, 0, PRN_BUF_SIZE);
     }
     return ok;
 }
@@ -25,9 +39,75 @@ int flush_prn_buf(void)
 int prn_buf_add(unsigned char c)
 {
     prn_buf[prn_buf_len++] = c;
+    last_activity = timer_counter;
+    flush_pending = 0;
     if (prn_buf_len >= PRN_BUF_SIZE)
         return flush_prn_buf();
     return 1;
+}
+
+// Called from INT 08h wrapper in iwrap.asm — DS=CS on entry
+void timer_tick(void)
+{
+    timer_counter++;
+    if (prn_buf_len > 0 && (timer_counter - last_activity) >= AUTO_FLUSH_TICKS) {
+        if (indos_flag && *indos_flag == 0) {
+            flush_prn_buf();
+            last_activity = timer_counter;
+        } else {
+            flush_pending = 1;  // DOS busy — INT 28h will pick it up
+        }
+    }
+}
+
+// Called from INT 28h (DOS idle) — flush unconditionally
+void idle_flush(void)
+{
+    flush_pending = 0;
+    flush_prn_buf();
+}
+
+void install_timer_handler(void)
+{
+    void (__interrupt __far *old)(void);
+    uint16_t indos_seg, indos_off;
+
+    // Get InDOS flag address via INT 21h AH=34h
+    _asm {
+        mov  ah, 34h
+        int  21h
+        mov  indos_off, bx
+        mov  indos_seg, es
+    }
+    indos_flag = (uint8_t far *)MK_FP(indos_seg, indos_off);
+
+    old = _dos_getvect(0x08);
+    old_timer_off = FP_OFF(old);
+    old_timer_seg = FP_SEG(old);
+    _dos_setvect(0x08, MK_FP(getCS(), (uint16_t)timer_vect));
+
+    old = _dos_getvect(0x28);
+    old_idle_off = FP_OFF(old);
+    old_idle_seg = FP_SEG(old);
+    _dos_setvect(0x28, MK_FP(getCS(), (uint16_t)idle_vect));
+
+    timer_counter = 0;
+    last_activity = 0;
+    flush_pending = 0;
+}
+
+void uninstall_timer_handler(void)
+{
+    if (old_timer_seg) {
+        _dos_setvect(0x08, (void (__interrupt __far *)(void))MK_FP(old_timer_seg, old_timer_off));
+        old_timer_seg = 0;
+        old_timer_off = 0;
+    }
+    if (old_idle_seg) {
+        _dos_setvect(0x28, (void (__interrupt __far *)(void))MK_FP(old_idle_seg, old_idle_off));
+        old_idle_seg = 0;
+        old_idle_off = 0;
+    }
 }
 
 

--- a/printer/commands.c
+++ b/printer/commands.c
@@ -16,6 +16,7 @@ static volatile uint16_t timer_counter = 0;
 static volatile uint16_t last_activity = 0;
 static volatile uint8_t flush_pending = 0;
 static uint8_t far *indos_flag = NULL;
+static uint8_t buffering_enabled = 0;
 
 // Defined in iwrap.asm
 extern uint16_t old_timer_off;
@@ -39,6 +40,8 @@ int flush_prn_buf(void)
 int prn_buf_add(unsigned char c)
 {
     prn_buf[prn_buf_len++] = c;
+    if (!buffering_enabled)
+        return flush_prn_buf();
     last_activity = timer_counter;
     flush_pending = 0;
     if (prn_buf_len >= PRN_BUF_SIZE)
@@ -90,6 +93,14 @@ void install_timer_handler(void)
     old_idle_off = FP_OFF(old);
     old_idle_seg = FP_SEG(old);
     _dos_setvect(0x28, MK_FP(getCS(), (uint16_t)idle_vect));
+
+    // Buffer + timer + INT 28h require DOS 3.0+
+    _asm {
+        mov  ah, 30h
+        int  21h
+        mov  buffering_enabled, al
+    }
+    buffering_enabled = (buffering_enabled >= 3) ? 1 : 0;
 
     timer_counter = 0;
     last_activity = 0;

--- a/printer/commands.h
+++ b/printer/commands.h
@@ -34,5 +34,9 @@ extern uint16_t Unknown_cmd(SYSREQ far *req);
 
 extern int flush_prn_buf(void);
 extern int prn_buf_add(unsigned char c);
+extern void idle_flush(void);
+extern void dos_flush(void);
+extern void install_timer_handler(void);
+extern void uninstall_timer_handler(void);
 
 #endif /* _COMMANDS_H */

--- a/printer/init.c
+++ b/printer/init.c
@@ -38,6 +38,7 @@ union REGS regs;
 extern void *config_env, *driver_end;
 
 extern void set17(void);
+extern void install_timer_handler(void);
 
 #pragma data_seg("_CODE")
 
@@ -64,6 +65,8 @@ uint16_t Init_cmd(SYSREQ far *req)
   consolef("Installed\n");
   set17();
   consolef("INT 17 functions installed\n");
+  install_timer_handler();
+  consolef("Auto-flush timer installed\n");
 
   return OP_COMPLETE;
 }

--- a/printer/iwrap.asm
+++ b/printer/iwrap.asm
@@ -1,5 +1,7 @@
 _TEXT	segment word public 'CODE'
 	extern	int17_:near
+	extern	idle_flush_:near
+	extern	timer_tick_:near
 
 	; Macro to create an interrupt wrapper for a given C function
 INTERRUPT MACRO func
@@ -33,6 +35,76 @@ INTERRUPT MACRO func
 ENDM
 
 	INTERRUPT	int17_
+
+; Storage for old INT 08h handler address
+	PUBLIC	_old_timer_off
+	PUBLIC	_old_timer_seg
+_old_timer_off	dw	0
+_old_timer_seg	dw	0
+
+; Storage for old INT 28h handler address
+	PUBLIC	_old_idle_off
+	PUBLIC	_old_idle_seg
+_old_idle_off	dw	0
+_old_idle_seg	dw	0
+
+; INT 08h timer wrapper — sets DS=CS, calls timer_tick_, chains to old handler
+	PUBLIC	timer_vect_
+timer_vect_ PROC NEAR
+	push	ax
+	push	bx
+	push	cx
+	push	dx
+	push	si
+	push	di
+	push	bp
+	push	ds
+	push	es
+	push	cs
+	pop	ds
+
+	call	timer_tick_
+
+	pop	es
+	pop	ds
+	pop	bp
+	pop	di
+	pop	si
+	pop	dx
+	pop	cx
+	pop	bx
+	pop	ax
+	jmp	dword ptr cs:[_old_timer_off]
+timer_vect_ ENDP
+
+; INT 28h idle wrapper — sets DS=CS, calls idle_flush_, chains to old handler
+	PUBLIC	idle_vect_
+idle_vect_ PROC NEAR
+	push	ax
+	push	bx
+	push	cx
+	push	dx
+	push	si
+	push	di
+	push	bp
+	push	ds
+	push	es
+	push	cs
+	pop	ds
+
+	call	idle_flush_
+
+	pop	es
+	pop	ds
+	pop	bp
+	pop	di
+	pop	si
+	pop	dx
+	pop	cx
+	pop	bx
+	pop	ax
+	jmp	dword ptr cs:[_old_idle_off]
+idle_vect_ ENDP
 
 _TEXT	ends
 


### PR DESCRIPTION
Ensure that print buffer is flushed after every print.
Works well on DOS 3.3 and up.  
Attempts to do byte-by-byte without the print buffer on DOS < 3.3.